### PR TITLE
Wrap help file to 78 chars

### DIFF
--- a/doc/expand_region.txt
+++ b/doc/expand_region.txt
@@ -29,7 +29,7 @@ Emac's 'expand-region': https://github.com/magnars/expand-region.el
 IntellJ's 'syntax aware selection':
 http://www.jetbrains.com/idea/documentation/tips/#tips_code_editing
 Eclipse's 'select enclosing element':
-http://stackoverflow.com/questions/4264047/intellij-ctrlw-equivalent-shortcut-in-eclipse
+http://stackoverflow.com/questions/4264047/
 
 ==============================================================================
 2. Usage                                                 *expand-region-usage*
@@ -55,42 +55,65 @@ available regions to expand/shrink to. The value corresponding to each plugin
 indicates whether text object is recursive. A recursive text object is
 continually expanded until the region no longer gets larger. >
 
-    " Default settings. (NOTE: Remove comments in dictionary before sourcing)
+    " Default settings.
+    " (NOTE: Remove comments in dictionary before sourcing)
     let g:expand_region_text_objects = {
           \ 'iw'  :0,
           \ 'iW'  :0,
           \ 'i"'  :0,
           \ 'i''' :0,
-          \ 'i]'  :1, " Support nesting of square brackets
-          \ 'ib'  :1, " Support nesting of parentheses
-          \ 'iB'  :1, " Support nesting of braces
-          \ 'il'  :0, " 'inside line'. Available through https://github.com/kana/vim-textobj-line
+          " Support nesting of square brackets
+          \ 'i]'  :1,
+          " Support nesting of parentheses
+          \ 'ib'  :1,
+          " Support nesting of braces
+          \ 'iB'  :1,
+          " 'inside line'. Available through
+          " https://github.com/kana/vim-textobj-line
+          \ 'il'  :0,
           \ 'ip'  :0,
-          \ 'ie'  :0, " 'entire file'. Available through https://github.com/kana/vim-textobj-entire
+          " 'entire file'. Available through
+          " https://github.com/kana/vim-textobj-entire
+          \ 'ie'  :0,
           \ }
 <
 
 You can extend the global default dictionary by calling
 'expand_region#custom_text_objects'. >
 
-    " Extend the global default (NOTE: Remove comments in dictionary before sourcing)
+    " Extend the global default
+    " (NOTE: Remove comments in dictionary before sourcing)
     call expand_region#custom_text_objects({
-          \ "\/\\n\\n\<CR>": 1, " Motions are supported as well. Here's a search motion that finds a blank line
-          \ 'a]' :1, " Support nesting of 'around' brackets
-          \ 'ab' :1, " Support nesting of 'around' parentheses
-          \ 'aB' :1, " Support nesting of 'around' braces
-          \ 'ii' :0, " 'inside indent'. Available through https://github.com/kana/vim-textobj-indent
-          \ 'ai' :0, " 'around indent'. Available through https://github.com/kana/vim-textobj-indent
+          " Motions are supported as well. Here's a search motion that finds a
+          " blank line
+          \ "\/\\n\\n\<CR>": 1,
+          " Support nesting of 'around' brackets
+          \ 'a]' :1,
+          " Support nesting of 'around' parentheses
+          \ 'ab' :1,
+          " Support nesting of 'around' braces
+          \ 'aB' :1,
+          " 'inside indent'. Available through
+          " https://github.com/kana/vim-textobj-indent
+          \ 'ii' :0,
+          " 'around indent'. Available through
+          " https://github.com/kana/vim-textobj-indent
+          \ 'ai' :0,
           \ })
 <
 
 You can further customize the text objects dictionary on a per filetype basis
 by defining global variables like 'g:expand_region_text_objects_{ft}'. >
 
-    " Use the following setting for ruby. (NOTE: Remove comments in dictionary  before sourcing)
+    " Use the following setting for ruby.
+    " (NOTE: Remove comments in dictionary  before sourcing)
     let g:expand_region_text_objects_ruby = {
-          \ 'im' :0, " 'inner method'. Available through https://github.com/vim-ruby/vim-ruby
-          \ 'am' :0, " 'around method'. Available through https://github.com/vim-ruby/vim-ruby
+          " 'inner method'. Available through
+          " https://github.com/vim-ruby/vim-ruby
+          \ 'im' :0,
+          " 'around method'. Available through
+          " https://github.com/vim-ruby/vim-ruby
+          \ 'am' :0,
           \ }
 <
 


### PR DESCRIPTION
- Modified comment style within dictionaries - use line-mode delete to
  remove comments which is easier IMO.
- Shorten StackOverflow link so it fits (still points to the same
  question)
